### PR TITLE
[FIX] remove navbar after cloning it and increase top attribute

### DIFF
--- a/website_theme_flexible/static/src/css/website_theme_flexible.editor.css
+++ b/website_theme_flexible/static/src/css/website_theme_flexible.editor.css
@@ -2,7 +2,7 @@
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
 
 header .navbar-fixed-top {
-    top: 34px;
+    top: 46px;
 }
 
 .dropdown-menu .colorpicker {

--- a/website_theme_flexible/static/src/js/website_theme_flexible.frontend.js
+++ b/website_theme_flexible/static/src/js/website_theme_flexible.frontend.js
@@ -14,6 +14,7 @@ odoo.define('website_theme_flexible.frontend', function(require) {
             var navbar_clone = navbar.clone();
             navbar_clone.addClass('navbar-fixed-top');
             header.append(navbar_clone);
+            navbar.remove();
         }
     });
 });

--- a/website_theme_flexible/static/src/js/website_theme_flexible.frontend.js
+++ b/website_theme_flexible/static/src/js/website_theme_flexible.frontend.js
@@ -14,7 +14,6 @@ odoo.define('website_theme_flexible.frontend', function(require) {
             var navbar_clone = navbar.clone();
             navbar_clone.addClass('navbar-fixed-top');
             header.append(navbar_clone);
-            navbar.remove();
         }
     });
 });


### PR DESCRIPTION
Increase the top css attribute of navbar-fixed-top class inside
header node. After cloning the navbar, the original navbar was
left there for some reason which made navbar ugly.